### PR TITLE
Support for AppCode 2021.1 SDK

### DIFF
--- a/src/main/java/codes/seanhenry/transformer/FunctionTransformer.kt
+++ b/src/main/java/codes/seanhenry/transformer/FunctionTransformer.kt
@@ -34,8 +34,8 @@ class FunctionTransformer: SwiftVisitor() {
         resolvedReturnType,
         parameters,
         declarationText,
-        element.throwsClause?.isThrows == true,
-        element.throwsClause?.isRethrows == true)
+        element.asyncThrowsClause?.isThrows == true,
+        element.asyncThrowsClause?.isRethrows == true)
   }
 
   private fun transformGenericParameters(clause: SwiftGenericParameterClause?): List<String> {

--- a/src/main/java/codes/seanhenry/transformer/TypePatternTransformer.kt
+++ b/src/main/java/codes/seanhenry/transformer/TypePatternTransformer.kt
@@ -86,7 +86,7 @@ class TypePatternTransformer : SwiftVisitor() {
   override fun visitClosureExpression(element: SwiftClosureExpression) {
     val arguments = transformClosureArguments(element)
     val returnType = transformClosureReturnType(element)
-    val throws = element.closureSignature?.throwsClause?.isThrows == true
+    val throws = element.closureSignature?.asyncThrowsClause?.isThrows == true
     transformedType = FunctionType(arguments, returnType, throws)
     if (element.parent is SwiftCallExpression) {
       transformedType = returnType

--- a/src/main/java/codes/seanhenry/transformer/TypeTransformer.kt
+++ b/src/main/java/codes/seanhenry/transformer/TypeTransformer.kt
@@ -5,7 +5,7 @@ import com.intellij.psi.PsiElement
 import com.jetbrains.swift.psi.*
 
 class TypeTransformer : SwiftVisitor() {
-  
+
   companion object {
     fun transform(element: PsiElement): Type? {
       val visitor = TypeTransformer()
@@ -86,10 +86,10 @@ class TypeTransformer : SwiftVisitor() {
         .items
         .mapNotNull { transform(it) }
     val returnType = transform(types[1])
-    transformedType = FunctionType(arguments, returnType ?: TypeIdentifier.EMPTY_TUPLE, isThrowing(element.throwsClause))
+    transformedType = FunctionType(arguments, returnType ?: TypeIdentifier.EMPTY_TUPLE, isThrowing(element.asyncThrowsClause))
   }
 
-  private fun isThrowing(clause: SwiftThrowsClause?): Boolean {
+  private fun isThrowing(clause: SwiftAsyncThrowsClause?): Boolean {
     return clause?.isThrows ?: false
   }
 


### PR DESCRIPTION
Plugin crashes with new AppCode 2021.1 because of changes in embedded SDK. Some compilation issues are fixed and it should now work. It is perhaps not back compatible>